### PR TITLE
Defined width dimensions of the extension

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,17 +1,3 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
 
 a {
   font-weight: 500;

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -62,13 +62,13 @@ export default function App() {
     return (
         <div
             style={{
-                padding: "20px",
+                padding: "16px",
                 width: "340px",
                 backgroundColor: "#121212",
                 borderRadius: "12px",
                 color: "#e0e0e0",
                 fontFamily: "'Segoe UI', sans-serif",
-                boxShadow: "0 4px 16px rgba(0, 0, 0, 0.5)",
+                
             }}
         >
             <h3 style={{ marginTop: 0, fontSize: "1.6rem", color: "#ffffff", marginBottom: "12px" }}>

--- a/src/popup/RequestReferral.css
+++ b/src/popup/RequestReferral.css
@@ -1,10 +1,11 @@
+
 .popup-container {
   padding: 16px;
-  width: 300px;
+  width: 340px;
   font-family: 'Segoe UI', sans-serif;
-  background-color: #1e1e2f; /* Dark background */
+  background-color: #2f3a9e; /* Dark background */
   border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+ 
   color: #f0f0f0; /* Light text */
 }
 


### PR DESCRIPTION
I made changes to three files:

1. `index.css` - Removed root css because it was boiler plate code and wasn't required
2. `popup/App.tsx` - Updated padding and removed `boxshadow` css attribute.
3. `src/popup/RequestReferral.css` - Updated multiple css attributes.

<img width="481" height="402" alt="Screenshot 2025-08-08 235428" src="https://github.com/user-attachments/assets/41591340-2a09-4e0a-ae88-543230ca9204" />


---

<img width="478" height="453" alt="image" src="https://github.com/user-attachments/assets/d493c37b-ee4d-40da-a924-c78a1fc9da1b" />
